### PR TITLE
Update Runner and Generator to accept both raw code and files or dire…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.2.1
-  - 2.2.2
-  - 2.2.3
+  - 2.2.6
+  - 2.4.0
 before_install: gem install bundler -v 1.10.4

--- a/spec/fixtures/controllers/reservations_controller.rb
+++ b/spec/fixtures/controllers/reservations_controller.rb
@@ -11,8 +11,6 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.new(reservation_params)
     if @reservation.save
       ReservationMailer.reservation(@reservation).deliver_later
-      redirect_to charter_path, notice: "Thank you for contacting us. We'll get back to you at our earliest convenience."
-    elsif params[:duder].nil? && "whodat" != params[:name]
       # some other crud
     else
       request.flash[:errors] = @reservation.errors.full_messages
@@ -28,7 +26,6 @@ class ReservationsController < ApplicationController
 
   def config_nav
     @current_page = :charter
-    @page_title = 'Contact'
   end
 
 end

--- a/spec/lib/rspec/scaffold/generator_spec.rb
+++ b/spec/lib/rspec/scaffold/generator_spec.rb
@@ -2,12 +2,11 @@ require 'spec_helper'
 
 describe RSpec::Scaffold::Generator do
   let(:file) { FIXTURE_ROOT.join('report.rb') }
-
-  subject { described_class.new file }
+  let(:ryan) { Ryan.new(file) }
 
   describe '.perform' do
     it 'returns the spec for the given file as an array of lines' do
-      expect(subject.perform.join("\n")).to eq %Q(require "spec_helper"
+      expect(subject.perform(ryan).join("\n")).to eq %Q(require "spec_helper"
 
 describe Report do
   let(:message) {}
@@ -140,12 +139,11 @@ end
 )
     end
 
-
     context 'given a file with a long if/elsif/else' do
       let(:file) { FIXTURE_ROOT.join('extensions.rb') }
 
       it 'returns an array of lines for the file' do
-        expect(subject.perform.join("\n")).to eq %Q(require "spec_helper"
+        expect(subject.perform(ryan).join("\n")).to eq %Q(require "spec_helper"
 
 describe Extensions do
   subject { Class.new { include Extensions }.new }
@@ -229,7 +227,7 @@ end
       let(:file) { FIXTURE_ROOT.join('controllers/application_controller.rb') }
 
       it 'rejects multiline statements to protect the client from our shortcomings' do
-        expect(subject.perform.join("\n")).to eq %Q(require "spec_helper"
+        expect(subject.perform(ryan).join("\n")).to eq %Q(require "spec_helper"
 
 describe ApplicationController do
 
@@ -271,90 +269,91 @@ end
     end
   end
 
-  describe '#const' do
-    it 'returns the Ruby constant defined in the given file' do
-      expect(subject.const).to eq Report
+  describe 'Parsing functionality (Ryan)' do
+    describe '#const' do
+      it 'returns the Ruby constant defined in the given file' do
+        expect(ryan.name).to eq 'Report'
+      end
+
+      context 'when the constant is namespaced' do
+        let(:file) { FIXTURE_ROOT.join('mixins/helpers/date_helper.rb') }
+
+        it 'returns the correct constant' do
+          expect(ryan.name).to eq 'Mixins::Helpers::DateHelper'
+        end
+      end
     end
 
-    context 'when the constant is namespaced' do
-      let(:file) { FIXTURE_ROOT.join('mixins/helpers/date_helper.rb') }
+    describe '#name' do
+      it 'returns the name of the Ruby class in the given file' do
+        expect(ryan.name).to eq 'Report'
+      end
+    end
 
-      it 'returns the correct constant' do
-        expect(subject.const).to eq Mixins::Helpers::DateHelper
+    describe '#funcs' do
+      it 'returns an array with all the methods defined in the target file' do
+        expect(ryan.funcs).to be_a Array
+        expect(ryan.funcs.length).to eq 12
+        expect(ryan.funcs.select(&:class?).length).to eq 4
+        expect(ryan.funcs.reject(&:class?).length).to eq 8
+        expect(ryan.funcs.select(&:private?).length).to eq 2
+        expect(ryan.funcs.first.name).to eq :enqueue
+        expect(ryan.funcs.first.conditions.map(&:full_statement)).to eq ["return unless verification_code"]
+      end
+    end
+
+    describe '#initialization_args' do
+      it 'returns a list of args to initialize the class' do
+        expect(ryan.initialization_args).to eq [:message]
+      end
+
+      context 'when the subject takes multiple args' do
+        let(:file) { FIXTURE_ROOT.join('multiple_args.rb') }
+
+        it 'returns all the args' do
+          expect(ryan.initialization_args).to eq [:name, :age, :"*args"]
+        end
+      end
+
+      context 'when the subject takes no args' do
+        let(:file) { FIXTURE_ROOT.join('controllers/reservations_controller.rb') }
+
+        it 'returns an empty array' do
+          expect(ryan.initialization_args).to eq []
+        end
+      end
+    end
+
+    describe '#class?' do
+      context 'when the subject is a class' do
+        it 'returns true' do
+          expect(ryan).to be_class
+        end
+      end
+
+      context 'when the subject is a module' do
+        let(:file) { FIXTURE_ROOT.join('mixins/models.rb') }
+
+        it 'returns false' do
+          expect(ryan).to_not be_class
+        end
+      end
+    end
+
+    describe '#module?' do
+      context 'when the subject is a module' do
+        let(:file) { FIXTURE_ROOT.join('mixins/models.rb') }
+
+        it 'returns true' do
+          expect(ryan).to be_module
+        end
+      end
+
+      context 'when the subject is a class' do
+        it 'returns false' do
+          expect(ryan).to_not be_module
+        end
       end
     end
   end
-
-  describe '#name' do
-    it 'returns the name of the Ruby class in the given file' do
-      expect(subject.name).to eq 'Report'
-    end
-  end
-
-  describe '#funcs' do
-    it 'returns an array with all the methods defined in the target file' do
-      expect(subject.funcs).to be_a Array
-      expect(subject.funcs.length).to eq 12
-      expect(subject.funcs.select(&:class?).length).to eq 4
-      expect(subject.funcs.reject(&:class?).length).to eq 8
-      expect(subject.funcs.select(&:private?).length).to eq 2
-      expect(subject.funcs.first.name).to eq :enqueue
-      expect(subject.funcs.first.conditions.map(&:full_statement)).to eq ["return unless verification_code"]
-    end
-  end
-
-  describe '#initialization_args' do
-    it 'returns a list of args to initialize the class' do
-      expect(subject.initialization_args).to eq [:message]
-    end
-
-    context 'when the subject takes multiple args' do
-      let(:file) { FIXTURE_ROOT.join('multiple_args.rb') }
-
-      it 'returns all the args' do
-        expect(subject.initialization_args).to eq [:name, :age, :"*args"]
-      end
-    end
-
-    context 'when the subject takes no args' do
-      let(:file) { FIXTURE_ROOT.join('controllers/reservations_controller.rb') }
-
-      it 'returns an empty array' do
-        expect(subject.initialization_args).to eq []
-      end
-    end
-  end
-
-  describe '#class?' do
-    context 'when the subject is a class' do
-      it 'returns true' do
-        expect(subject).to be_class
-      end
-    end
-
-    context 'when the subject is a module' do
-      let(:file) { FIXTURE_ROOT.join('mixins/models.rb') }
-
-      it 'returns false' do
-        expect(subject).to_not be_class
-      end
-    end
-  end
-
-  describe '#module?' do
-    context 'when the subject is a module' do
-      let(:file) { FIXTURE_ROOT.join('mixins/models.rb') }
-
-      it 'returns true' do
-        expect(subject).to be_module
-      end
-    end
-
-    context 'when the subject is a class' do
-      it 'returns false' do
-        expect(subject).to_not be_module
-      end
-    end
-  end
-
 end

--- a/spec/lib/rspec/scaffold/runner_spec.rb
+++ b/spec/lib/rspec/scaffold/runner_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe RSpec::Scaffold::Runner do
+  describe '#generate_spec' do
+    let(:input) { FIXTURE_ROOT.join('multiple_args.rb') }
+
+    it 'returns a collection of lines used to build the spec file' do
+      expect(subject.generate_spec(input).join("\n")).to eq %Q(require "spec_helper"
+
+describe MultipleArgs do
+  let(:name) {}
+  let(:age) {}
+  let(:args) {}
+
+  subject { described_class.new name, age, *args }
+
+  describe ".__" do
+  end
+
+  describe "#initialize" do
+  end
+
+end
+)
+    end
+
+    context 'when given raw Ruby code' do
+      let(:input) { "class Admin::Super; def name() @name = String.random end end\n" }
+
+      it 'returns a collection of lines used to build the spec file' do
+        expect(subject.generate_spec(input).join("\n")).to eq %Q(require "spec_helper"
+
+describe Admin::Super do
+
+  subject { described_class.new  }
+
+  describe "#name" do
+    it "assigns @name" do
+    end
+  end
+
+end
+)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Update the `Generator` class to __not__ delegate to the `Ryan` class, as this was causing really weird behavior when trying to give it a string instead of a file.

The `Runner#generate_spec/1` method was promoted to public and accepts input that is passed directly to `Ryan`, which accepts raw code or a file.

Usage:
```ruby
runner = RSpec::Scaffold::Runner.new
runner.generate_spec("class Admin::Super; def name() @name = String.random end end\n")
# => ["require ...", ...]
```